### PR TITLE
Enable PDF and DOC uploads

### DIFF
--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -18,7 +18,14 @@ export const postRequestBodySchema = z.object({
         z.object({
           url: z.string().url(),
           name: z.string().min(1).max(2000),
-          contentType: z.enum(['image/png', 'image/jpg', 'image/jpeg']),
+          contentType: z.enum([
+            'image/png',
+            'image/jpg',
+            'image/jpeg',
+            'application/pdf',
+            'application/msword',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          ]),
         }),
       )
       .optional(),

--- a/app/(chat)/api/files/upload/route.ts
+++ b/app/(chat)/api/files/upload/route.ts
@@ -12,9 +12,19 @@ const FileSchema = z.object({
       message: 'File size should be less than 5MB',
     })
     // Update the file type based on the kind of files you want to accept
-    .refine((file) => ['image/jpeg', 'image/png'].includes(file.type), {
-      message: 'File type should be JPEG or PNG',
-    }),
+    .refine(
+      (file) =>
+        [
+          'image/jpeg',
+          'image/png',
+          'application/pdf',
+          'application/msword',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ].includes(file.type),
+      {
+        message: 'File type should be JPEG, PNG, PDF or DOC/DOCX',
+      },
+    ),
 });
 
 export async function POST(request: Request) {

--- a/components/preview-attachment.tsx
+++ b/components/preview-attachment.tsx
@@ -1,6 +1,6 @@
 import type { Attachment } from 'ai';
 
-import { LoaderIcon } from './icons';
+import { LoaderIcon, FileIcon } from './icons';
 
 export const PreviewAttachment = ({
   attachment,
@@ -24,8 +24,18 @@ export const PreviewAttachment = ({
               alt={name ?? 'An image attachment'}
               className="rounded-md size-full object-cover"
             />
+          ) : url ? (
+            <a
+              key={url}
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-muted-foreground"
+            >
+              <FileIcon />
+            </a>
           ) : (
-            <div className="" />
+            <FileIcon />
           )
         ) : (
           <div className="" />

--- a/public/files/sample.doc
+++ b/public/files/sample.doc
@@ -1,0 +1,1 @@
+Simple doc file.

--- a/public/files/sample.pdf
+++ b/public/files/sample.pdf
@@ -1,0 +1,10 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 0 >>
+endobj
+trailer
+<< /Root 1 0 R >>
+%%EOF

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -98,6 +98,20 @@ test.describe('Chat activity', () => {
     expect(assistantMessage.content).toBe('This painting is by Monet!');
   });
 
+  test('Upload pdf and doc attachments', async () => {
+    await chatPage.addPdfAttachment();
+    await chatPage.addDocAttachment();
+
+    await chatPage.isElementVisible('attachments-preview');
+    await chatPage.isElementVisible('input-attachment-loader');
+    await chatPage.isElementNotVisible('input-attachment-loader');
+
+    await chatPage.sendUserMessage('Check my files');
+
+    const userMessage = await chatPage.getRecentUserMessage();
+    expect(userMessage.attachments).toHaveLength(2);
+  });
+
   test('Call weather tool', async () => {
     await chatPage.sendUserMessage("What's the weather in sf?");
     await chatPage.isGenerationComplete();

--- a/tests/pages/chat.ts
+++ b/tests/pages/chat.ts
@@ -96,6 +96,36 @@ export class ChatPage {
     await this.page.getByTestId('attachments-button').click();
   }
 
+  async addPdfAttachment() {
+    this.page.on('filechooser', async (fileChooser) => {
+      const filePath = path.join(process.cwd(), 'public', 'files', 'sample.pdf');
+      const fileBuffer = fs.readFileSync(filePath);
+
+      await fileChooser.setFiles({
+        name: 'sample.pdf',
+        mimeType: 'application/pdf',
+        buffer: fileBuffer,
+      });
+    });
+
+    await this.page.getByTestId('attachments-button').click();
+  }
+
+  async addDocAttachment() {
+    this.page.on('filechooser', async (fileChooser) => {
+      const filePath = path.join(process.cwd(), 'public', 'files', 'sample.doc');
+      const fileBuffer = fs.readFileSync(filePath);
+
+      await fileChooser.setFiles({
+        name: 'sample.doc',
+        mimeType: 'application/msword',
+        buffer: fileBuffer,
+      });
+    });
+
+    await this.page.getByTestId('attachments-button').click();
+  }
+
   public async getSelectedModel() {
     const modelId = await this.page.getByTestId('model-selector').innerText();
     return modelId;


### PR DESCRIPTION
## Summary
- allow pdf/doc/docx files in upload endpoint
- support these file types in chat schema
- show generic file icon for non-image attachments
- add small sample pdf & doc for tests
- extend tests to cover pdf/doc uploads

## Testing
- `pnpm test` *(fails: ConnectTimeoutError when fetching pnpm)*